### PR TITLE
add function to rescue tokens sent by mistake to campaign contract

### DIFF
--- a/src/campaign/NudgeCampaign.sol
+++ b/src/campaign/NudgeCampaign.sol
@@ -341,6 +341,28 @@ contract NudgeCampaign is INudgeCampaign, AccessControl {
     emit CampaignStatusChanged(isActive);
   }
 
+  /// @notice Rescues tokens that were mistakenly sent to the contract
+  /// @param token Address of token to rescue
+  /// @dev Only callable by NUDGE_ADMIN_ROLE, can't rescue the reward token
+  /// @return amount Amount of tokens rescued
+  function rescueTokens(address token) external returns (uint256 amount) {
+    if (!factory.hasRole(factory.NUDGE_ADMIN_ROLE(), msg.sender)) {
+      revert Unauthorized();
+    }
+
+    if (token == rewardToken) {
+      revert CannotRescueRewardToken();
+    }
+
+    amount = getBalanceOfSelf(token);
+    if (amount > 0) {
+      _transfer(token, msg.sender, amount);
+      emit TokensRescued(token, amount);
+    }
+
+    return amount;
+  }
+
   /*//////////////////////////////////////////////////////////////////////////
                               VIEW FUNCTIONS                              
   //////////////////////////////////////////////////////////////////////////*/

--- a/src/campaign/interfaces/INudgeCampaign.sol
+++ b/src/campaign/interfaces/INudgeCampaign.sol
@@ -16,6 +16,7 @@ interface INudgeCampaign is IBaseNudgeCampaign {
   error NativeTokenTransferFailed();
   error EmptyParticipationsArray();
   error InvalidCampaignId();
+  error CannotRescueRewardToken();
 
   // Events
   event ParticipationInvalidated(uint256[] pIDs);
@@ -23,12 +24,14 @@ interface INudgeCampaign is IBaseNudgeCampaign {
   event FeesCollected(uint256 amount);
   event CampaignStatusChanged(bool isActive);
   event NudgeRewardClaimed(uint256 pID, address userAddress, uint256 rewardAmount);
+  event TokensRescued(address token, uint256 amount);
 
   function collectFees() external returns (uint256);
   function invalidateParticipations(uint256[] calldata pIDs) external;
   function withdrawRewards(uint256 amount) external;
   function setIsCampaignActive(bool isActive) external;
   function claimRewards(uint256[] calldata pIDs) external;
+  function rescueTokens(address token) external returns (uint256);
 
   // View functions
   function getBalanceOfSelf(address token) external view returns (uint256);


### PR DESCRIPTION
Add a function, rescueTokens(), which can be used by an address with the NUDGE_ADMIN_ROLE to rescue tokens (expect the reward token) that were mistakenly sent to a campaign contract.